### PR TITLE
Resolve DOIs securely

### DIFF
--- a/doi2bib
+++ b/doi2bib
@@ -71,8 +71,8 @@ for doi in "$@"; do
   # we do some encoding as needed.
   doi=${doi//+/%2B}
 
-  # we retrieve the data from http://dx.doi.org/
-  curl -s -LH "Accept: text/bibliography; style=bibtex" "http://dx.doi.org/${doi}" | \
+  # we retrieve the data from https://doi.org/
+  curl -s -LH "Accept: text/bibliography; style=bibtex" "https://doi.org/${doi}" | \
     sed -e $'s/^ *//' \
         -e $'s/}, /},\\\n  /g' \
         -e $'s/, /,\\\n  /1' \


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation use the new resolver.

Cheers!